### PR TITLE
fixed bazel warnings

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,8 @@
 cc_test(
     name = "test",
+    size = "small",
+    shard_count = 4,
+    args = ["-v high", "-d yes"],
     srcs = glob(["test/*.cpp"]),
     data = glob(["data/example_instances_rev1/*.json"]),
     deps = [


### PR DESCRIPTION
fixed following bazel warnings:
1. test size wasn't set: now the test size set to small
2. test sharding wasn't configured: now configured number of shards to 4